### PR TITLE
Flatten AND and OR expressions

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -221,15 +221,10 @@ impl BitAnd for Expr {
                 lhs.sort_unstable();
                 Expr::And(lhs)
             }
-            (Expr::And(mut lhs), rhs) => {
-                lhs.push(rhs);
-                lhs.sort_unstable();
-                Expr::And(lhs)
-            }
-            (lhs, Expr::And(mut rhs)) => {
-                rhs.insert(0, lhs);
-                rhs.sort_unstable();
-                Expr::And(rhs)
+            (Expr::And(mut a), b) | (b, Expr::And(mut a)) => {
+                a.push(b);
+                a.sort_unstable();
+                Expr::And(a)
             }
             (lhs, rhs) => Expr::And(if lhs < rhs {
                 vec![lhs, rhs]

--- a/src/expr/cnf.rs
+++ b/src/expr/cnf.rs
@@ -88,7 +88,7 @@ impl Not for CNF {
         // De Morgan's Law
         match self.0 {
             Expr::And(inner) => todo!(),
-            Expr::Or(a, b) => CNF(!*a & !*b),
+            Expr::Or(inner) => todo!(),
             a => CNF(!a),
         }
     }

--- a/src/expr/cnf.rs
+++ b/src/expr/cnf.rs
@@ -66,15 +66,19 @@ impl BitOr for CNF {
         match (self.0, rhs.0) {
             (Expr::And(lhs), Expr::And(rhs)) => {
                 // (a ∧ b) ∨ (c ∧ d) = (a ∨ c) ∧ (a ∨ d) ∧ (b ∨ c) ∧ (b ∨ d)
-                todo!()
+                let mut result = Vec::new();
+                for a in &lhs {
+                    for b in &rhs {
+                        result.push(a.clone() | b.clone());
+                    }
+                }
+                CNF(Expr::And(result))
             }
-            (Expr::And(lhs), c) => {
+            (Expr::And(inner), c) | (c, Expr::And(inner)) => {
                 // (a ∧ b) ∨ c = (a ∨ c) ∧ (b ∨ c)
-                todo!()
-            }
-            (a, Expr::And(rhs)) => {
-                // a ∨ (c ∧ d) = (a ∨ c) ∧ (a ∨ d)
-                todo!()
+                CNF(Expr::And(
+                    inner.into_iter().map(|a| a | c.clone()).collect(),
+                ))
             }
             (lhs, rhs) => CNF(lhs | rhs),
         }
@@ -87,8 +91,8 @@ impl Not for CNF {
     fn not(self) -> Self {
         // De Morgan's Law
         match self.0 {
-            Expr::And(inner) => todo!(),
-            Expr::Or(inner) => todo!(),
+            Expr::And(inner) => CNF(Expr::Or(inner.into_iter().map(Not::not).collect())),
+            Expr::Or(inner) => CNF(Expr::And(inner.into_iter().map(Not::not).collect())),
             a => CNF(!a),
         }
     }

--- a/src/expr/cnf.rs
+++ b/src/expr/cnf.rs
@@ -64,17 +64,17 @@ impl BitOr for CNF {
     fn bitor(self, rhs: Self) -> Self {
         // Distributive Law
         match (self.0, rhs.0) {
-            (Expr::And(a, b), Expr::And(c, d)) => {
+            (Expr::And(lhs), Expr::And(rhs)) => {
                 // (a ∧ b) ∨ (c ∧ d) = (a ∨ c) ∧ (a ∨ d) ∧ (b ∨ c) ∧ (b ∨ d)
-                CNF((*a.clone() | *c.clone()) & (*a | *d.clone()) & (*b.clone() | *c) & (*b | *d))
+                todo!()
             }
-            (Expr::And(a, b), c) => {
+            (Expr::And(lhs), c) => {
                 // (a ∧ b) ∨ c = (a ∨ c) ∧ (b ∨ c)
-                CNF((*a | c.clone()) & (*b | c))
+                todo!()
             }
-            (a, Expr::And(c, d)) => {
+            (a, Expr::And(rhs)) => {
                 // a ∨ (c ∧ d) = (a ∨ c) ∧ (a ∨ d)
-                CNF((a.clone() | *c) & (a | *d))
+                todo!()
             }
             (lhs, rhs) => CNF(lhs | rhs),
         }
@@ -87,7 +87,7 @@ impl Not for CNF {
     fn not(self) -> Self {
         // De Morgan's Law
         match self.0 {
-            Expr::And(a, b) => CNF(!*a | !*b),
+            Expr::And(inner) => todo!(),
             Expr::Or(a, b) => CNF(!*a & !*b),
             a => CNF(!a),
         }


### PR DESCRIPTION
- AND and OR expression trees are stored as flat list like `x0 ∧ x1 ∧ x2` instead of binary tree like `x0 ∧ (x1 ∧ x2)`
- To sort this list, an order of `Expr` is introduced.